### PR TITLE
App Bar

### DIFF
--- a/packages/core/app.vue
+++ b/packages/core/app.vue
@@ -6,12 +6,19 @@ const colorMode = useColorMode()
 const config = await useTntApi().loadConfig()
 if (config.colorMode) colorMode.preference = config.colorMode
 
+const bodyClass = computed(() => {
+  let klasses = []
+  if (isElectron()) klasses.push('electron')
+  if (gradient) klasses.push('bg-gradient-auto')
+  return klasses.join(' ')
+})
+
 useHead({
   titleTemplate: (titleChunk) => {
     return titleChunk ? `${titleChunk} - ${name}` : name
   },
   bodyAttrs: {
-    class: gradient ? 'bg-gradient-auto' : '',
+    class: bodyClass.value,
   },
 })
 </script>

--- a/packages/core/components/app/Header.vue
+++ b/packages/core/components/app/Header.vue
@@ -55,7 +55,7 @@ header.sticky.top-0
 </template>
 
 <style lang="postcss">
-header {
+body.electron header {
   @apply select-none;
   -webkit-app-region: drag;
   & a, button {

--- a/packages/core/components/app/Header.vue
+++ b/packages/core/components/app/Header.vue
@@ -53,3 +53,13 @@ header.sticky.top-0
             Icon(name="fa6-solid:xmark")/
             span.sr-only Close
 </template>
+
+<style lang="postcss">
+header {
+  -webkit-user-select: none;
+  -webkit-app-region: drag;
+  & a, button {
+    -webkit-app-region: no-drag;
+  }
+}
+</style>

--- a/packages/core/components/app/Header.vue
+++ b/packages/core/components/app/Header.vue
@@ -56,7 +56,7 @@ header.sticky.top-0
 
 <style lang="postcss">
 header {
-  -webkit-user-select: none;
+  @apply select-none;
   -webkit-app-region: drag;
   & a, button {
     -webkit-app-region: no-drag;


### PR DESCRIPTION
closes #81

Caught myself before pushing straight to main. Very simple little feature, but... haven't tested it in a browser. Potentially this needs to be conditional on whether or not the application is running in an Electron wrapper.

Adding conditional checking will be pretty easy though. Just check in the script or template part and conditionally give the header the `.app-bar` class or something like that.

You could also add this class (like a `.app` class) higher up, so that should we need to tweak other components with Electron-specific CSS we can just cascade from the body class.

But maybe it's valid, maybe it doesn't interfere with browser rendering... I kinda suspect it will though. Some browsers use webkit, right?

Also check and see if there is a Tailwind utility class we might use instead of writing the CSS directly. Why...? ...is a good question. It doesn't matter. I doubt there is one anyway...

There isn't, but there is one for user-select: https://tailwindcss.com/docs/user-select Make use of that so that we don't have to write both `-webkit-user-select` and `user-select` declarations.

By submitting this pull request, you agree to follow our Code of Conduct: https://github.com/thombruce/.github/blob/main/CODE_OF_CONDUCT.md

---

_Internal use. Do not delete._

- [ ] Tests passing
- [ ] Coverage sufficient
- [ ] Manual review
- [ ] No A11y regression
- [ ] Translations provided or not needed
